### PR TITLE
Feature #1 Make deployment script run portably

### DIFF
--- a/deployOnDocker.sh
+++ b/deployOnDocker.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 docker stop helloPayara5 || true
 docker rm   helloPayara5 || true
-docker run --name helloPayara5 -v ~/eclipse-workspace/Hello/target:/opt/payara/deployments -p 4848:4848 -p 8080:8080 payara/server-full:5.193
+docker run --name helloPayara5 -v $PWD/target:/opt/payara/deployments -p 4848:4848 -p 8080:8080 payara/server-full:5.193


### PR DESCRIPTION
The deployment script was hard-coded to the original workspace
environment and needed to be made portable for other locations.

The solution replaced hard-coded path prefix and instead determined
it at runtime. That value was used to set the local deployment
directory, which is used as the mount volume for the Docker
deployment instance.