### PR TITLE
Bug #3 Docker running Payara reports SEVERE messages

### DIFF
--- a/deployOnDocker.sh
+++ b/deployOnDocker.sh
@@ -1,4 +1,15 @@
 #!/bin/sh
+######################################################################               
+# This script creates a deployment directory, copies the current
+# application's build WAR file into the directory, and mounts that
+# directory to the running Docker instance's Payara deployment
+# directory.
+#
+# The Docker instance exposes ports 4848, 8080 to the localhost
+######################################################################
+rm -Rf ./DEPLOY
+mkdir ./DEPLOY
+cp ./target/Hello.war ./DEPLOY
 docker stop helloPayara5 || true
 docker rm   helloPayara5 || true
-docker run --name helloPayara5 -v $PWD/target:/opt/payara/deployments -p 4848:4848 -p 8080:8080 payara/server-full:5.193
+docker run --name helloPayara5 -v $PWD/DEPLOY:/opt/payara/deployments -p 4848:4848 -p 8080:8080 payara/server-full:5.193


### PR DESCRIPTION
After looking at the log messages it appeared the other files and
directories in /target where being read by Payara's autodeployment
and throwing errors for not being a WAR file. The best solution
would be to isolate the target Hello.war file to it's own deployment
directory without any extranious files.

The deployment script was modified to manage the cleaning, creation,
and copying of the WAR file into a dedicated deployment directory.
Comments were also added to the script, explaining what it does.