### PR TITLE
Feature #5 Expose SSL to application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,26 @@
 # helloPayaraDocker
+
+**Overview**
+
 Starter Java EE 8 application on Payara and Docker
 
+**Payara Docker Hub Documentation**
+
+https://hub.docker.com/r/payara/server-full
+
+Summary
+
+ - Payara Admin Console
+    - http://localhost:4848 
+    - username/pwd: admin/admin
+ - Hello app
+    - http://localhost:8080/Hello/
+    - https://localhost:8181/Hello/
+
 # Build
-mvn clean package
+
+`mvn clean package`
 
 # RUN
 
-Execute: deployOnDocker.sh
+`deployOnDocker.sh`

--- a/deployOnDocker.sh
+++ b/deployOnDocker.sh
@@ -5,11 +5,12 @@
 # directory to the running Docker instance's Payara deployment
 # directory.
 #
-# The Docker instance exposes ports 4848, 8080 to the localhost
+# The Docker instance exposes ports 4848, 8080, and 8181 to the
+# localhost.
 ######################################################################
 rm -Rf ./DEPLOY
 mkdir ./DEPLOY
 cp ./target/Hello.war ./DEPLOY
 docker stop helloPayara5 || true
 docker rm   helloPayara5 || true
-docker run --name helloPayara5 -v $PWD/DEPLOY:/opt/payara/deployments -p 4848:4848 -p 8080:8080 payara/server-full:5.193
+docker run --name helloPayara5 -v $PWD/DEPLOY:/opt/payara/deployments -p 4848:4848 -p 8080:8080 -p 8181:8181 payara/server-full:5.193


### PR DESCRIPTION
The Payara server runs the application over HTTP and HTTPS (8080/8181).
The deploy script only mapped the HTTP port to the localhost. To view
the application under SSL, the deploy script was modified to expose
port 8181 to the localhost. The script's documentation was updated to
reflect this change.

Additionally, the README.md was updated to better reflect the current
usage of the application.