### PR TITLE
Add RESTful API and Persistance for Fish

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,15 @@ Summary
 # RUN
 
 `deployOnDocker.sh`
+
+# RESTful API
+
+`curl -XPOST -H "Content-type: application/json" -d "{\"className\":\"Actinopterygii\",\"orderName\":\"Salmoniformes\",\"familyName\":\"Salmoninae\",\"genusName\":\"Hucho\",\"speciesName\":\"taimen\",\"commonName\":\"Siberian taimen\"}" http://localhost:8080/Hello/resources/fish`
+
+`curl -i -XGET http://localhost:8080/Hello/resources/fish/`
+
+`curl -i -XGET http://localhost:8080/Hello/resources/fish/1`
+
+`curl -XPUT -H "Content-type: application/json" -d "{\"className\":\"Actinopterygii\",\"orderName\":\"Salmoniformes\",\"familyName\":\"Salmoninae\",\"genusName\":\"Hucho\",\"speciesName\":\"taimen\",\"commonName\":\"Awesome Siberian taimen\"}" http://localhost:8080/Hello/resources/fish/1`
+
+`curl -i -XDELETE http://localhost:8080/Hello/resources/fish/1`

--- a/src/main/java/org/walsted/hello/fish/boundary/FishResource.java
+++ b/src/main/java/org/walsted/hello/fish/boundary/FishResource.java
@@ -1,0 +1,101 @@
+package org.walsted.hello.fish.boundary;
+
+import java.net.URI;
+import java.util.List;
+
+import javax.ejb.EJB;
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import javax.validation.Valid;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.Response.Status;
+
+import org.walsted.hello.fish.control.FishService;
+import org.walsted.hello.fish.entity.Fish;
+
+@Path("fish")
+public class FishResource {
+
+	@EJB
+	private FishService service;
+
+	@Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
+	@GET
+	public JsonArray find() {
+		return newJsonArray(service.findAll());
+	}
+
+	@Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
+	@GET
+	@Path("/{id}")
+	public JsonObject findById(@PathParam("id") long id) {
+		return buildJsonObject(service.find(id));
+	}
+
+	@POST
+	public Response create(@Valid Fish fish) {
+		service.create(fish);
+		URI newEntityUri = UriBuilder.fromResource(FishResource.class).path(fish.getId().toString()).build();
+		return Response.created(newEntityUri).build();
+	}
+
+	@PUT
+	@Consumes(MediaType.APPLICATION_JSON)
+	@Path("{id}")
+	public Response update(@PathParam("id") long id, Fish entity) {
+		// Set ID, since you don't know how many properties are present.
+		entity.setId(id);
+		service.update(entity);
+		return Response.ok().build();
+	}
+
+	@DELETE
+	@Path("/{id}")
+	public Response deleteById(@PathParam("id") long id) {
+		try {
+			service.delete(id);
+			return Response.status(Status.OK).build();
+		} catch (Exception e) {
+			System.err.println("Delete: " + e.getMessage());
+			return Response.status(Status.NOT_FOUND).build();
+		}
+	}
+
+	///////////////////////////////////////////////////////////////////////////
+	//
+
+	private JsonArray newJsonArray(List<Fish> list) {
+		JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
+		for (Fish entity : list) {
+			try {
+				arrayBuilder.add(buildJsonObject(entity));
+			} catch (RuntimeException e) {
+				System.err.println("Could not build JsonObject for: " + entity);
+			}
+		}
+		return arrayBuilder.build();
+	}
+
+	private JsonObject buildJsonObject(Fish fish) {
+		JsonObjectBuilder builder = Json.createObjectBuilder().add("id", fish.getId())
+				.add("className", fish.getClassName()).add("orderName", fish.getOrderName())
+				.add("familyName", fish.getFamilyName()).add("genusName", fish.getGenusName())
+				.add("speciesName", fish.getSpeciesName()).add("commonName", fish.getCommonName());
+
+		return builder.build();
+	}
+
+}

--- a/src/main/java/org/walsted/hello/fish/control/FishService.java
+++ b/src/main/java/org/walsted/hello/fish/control/FishService.java
@@ -1,0 +1,53 @@
+	package org.walsted.hello.fish.control;
+
+import java.util.List;
+
+import javax.ejb.Stateless;
+import javax.ejb.TransactionManagement;
+import javax.ejb.TransactionManagementType;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityNotFoundException;
+import javax.persistence.PersistenceContext;
+import javax.persistence.TypedQuery;
+
+import org.walsted.hello.fish.entity.Fish;
+
+@Stateless
+@TransactionManagement(TransactionManagementType.CONTAINER)
+public class FishService {
+
+	@PersistenceContext(unitName = "fish")
+	private EntityManager entityManager;
+
+	public void create(Fish entity) {
+		entityManager.persist(entity);
+	}
+
+	public Fish find(Long id) {
+		Fish entity = entityManager.find(Fish.class, id);
+		if (entity == null) {
+			throw new EntityNotFoundException("No Fish found for id: " + id);
+		}
+		return entity;
+	}
+	
+	public Fish update(Fish entity) {
+		Fish merged = entityManager.merge(entity);
+		return merged;
+	}
+	
+	public void delete(Long id) {
+		Fish entity = find(id);
+		entityManager.remove(entity);
+	}
+	
+	public List<Fish> findAll() {
+		try {
+			TypedQuery<Fish> query = entityManager
+					.createQuery("SELECT e FROM Fish e ORDER BY e.familyName, e.genusName, e.speciesName ASC", Fish.class);
+			return query.getResultList();
+		} catch(RuntimeException e) {
+			throw new RuntimeException("Could not get list: "+ e.getMessage());
+		}
+	}
+}

--- a/src/main/java/org/walsted/hello/fish/entity/Fish.java
+++ b/src/main/java/org/walsted/hello/fish/entity/Fish.java
@@ -1,0 +1,98 @@
+package org.walsted.hello.fish.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "fish")
+public class Fish {
+
+	private Long id;
+
+	private String className;
+
+	private String orderName;
+
+	private String familyName;
+
+	private String genusName;
+
+	private String speciesName;
+
+	private String commonName;
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "fish_id")
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getClassName() {
+		return className;
+	}
+
+	public void setClassName(String className) {
+		this.className = className;
+	}
+
+	@Column(name = "order_name")
+	public String getOrderName() {
+		return orderName;
+	}
+
+	public void setOrderName(String orderName) {
+		this.orderName = orderName;
+	}
+
+	@Column(name = "family_name")
+	public String getFamilyName() {
+		return familyName;
+	}
+
+	public void setFamilyName(String familyName) {
+		this.familyName = familyName;
+	}
+
+	@Column(name = "genus_name")
+	public String getGenusName() {
+		return genusName;
+	}
+
+	public void setGenusName(String genusName) {
+		this.genusName = genusName;
+	}
+
+	@Column(name = "species_name")
+	public String getSpeciesName() {
+		return speciesName;
+	}
+
+	public void setSpeciesName(String speciesName) {
+		this.speciesName = speciesName;
+	}
+
+	@Column(name = "common_name")
+	public String getCommonName() {
+		return commonName;
+	}
+
+	public void setCommonName(String commonName) {
+		this.commonName = commonName;
+	}
+
+	@Override
+	public String toString() {
+		return "Fish [id=" + id + ", className=" + className + ", orderName=" + orderName + ", familyName=" + familyName
+				+ ", genusName=" + genusName + ", speciesName=" + speciesName + ", commonName=" + commonName + "]";
+	}
+
+}

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="2.1"
+	xmlns="http://java.sun.com/xml/ns/persistence"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence
+  http://java.sun.com/xml/ns/persistence/persistence_2_1.xsd">
+	<persistence-unit name="fish"
+		transaction-type="JTA">
+		<jta-data-source>java:comp/DefaultDataSource</jta-data-source>
+		<class>org.walsted.hello.fish.entity.Fish</class>
+		<properties>
+			<!-- Options: [ none | create | drop-and-create | drop] -->
+			<property
+				name="javax.persistence.schema-generation.database.action"
+				value="create" />
+		</properties>
+	</persistence-unit>
+</persistence>

--- a/testDeployOnDocker.sh
+++ b/testDeployOnDocker.sh
@@ -5,23 +5,24 @@
 # directory, and mounts that directory to the running Docker 
 # instance.
 #
+# Note: this Test-instance uses bundled H2 database.
+#
 # The Docker instance exposes ports 4848, 8080, and 8181 to the
 # localhost.
 ######################################################################
 # Environment setup
 IMAGE_NAME=payara/server-full:5.193
-INSTANCE_NAME=myFinance
+INSTANCE_NAME=helloTest
 PORTS="-p 4848:4848 -p 8080:8080 -p 8181:8181"
-DOCKER_DIR=/tmp/DOCKER_MYFINANCE
+DOCKER_DIR=/tmp/DOCKER_HELLO
 DEPLOY_DIR=$DOCKER_DIR/deployments
 SCRIPTS_DIR=$DOCKER_DIR/scripts
 # Commands
 rm -Rf $DOCKER_DIR
 mkdir -p $DEPLOY_DIR
 mkdir -p $SCRIPTS_DIR
-cp ./target/myFinance.war          $DEPLOY_DIR
-cp postboot.txt                    $SCRIPTS_DIR
-cp ~/.m2/repository/mysql/mysql-connector-java/8.0.21/mysql-connector-java-8.0.21.jar $SCRIPTS_DIR
+cp ./target/Hello.war          $DEPLOY_DIR
 docker stop $INSTANCE_NAME || true
 docker rm   $INSTANCE_NAME || true
-docker run --name $INSTANCE_NAME --rm -d $PORTS -v $DEPLOY_DIR:/opt/payara/deployments -v $SCRIPTS_DIR:/tmp -e POSTBOOT_COMMANDS=/tmp/postboot.txt $IMAGE_NAME
+docker run --name $INSTANCE_NAME --rm -d $PORTS -v $DEPLOY_DIR:/opt/payara/deployments $IMAGE_NAME
+


### PR DESCRIPTION
This commit includes adding Persistance API configuration, Stateless EJB,
and Fish entity. README.md has curl examples to create, read, update, and
delete Fish records.